### PR TITLE
Extending Matern kernel options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # VSCode
 .vscode/*
+.vscode/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json

--- a/training/gordon-group/src/CustomMLPipeline/machineLearning/GPRegression/kernels/SklearnGPRKernelMatern.c3typ
+++ b/training/gordon-group/src/CustomMLPipeline/machineLearning/GPRegression/kernels/SklearnGPRKernelMatern.c3typ
@@ -4,8 +4,8 @@
 * See: https://scikit-learn.org/stable/modules/generated/sklearn.gaussian_process.kernels.Matern.html#sklearn.gaussian_process.kernels.Matern
 */
 type SklearnGPRKernelMatern {
-    // Constant that defines the kernel length scale
-    lengthScale: !double
+    // Array of constants which define an anisotropic kernel's length scales
+    lengthScale: !Float32Array
     // Constant prepended to the kernel function (for the variance K(x,x))
     coefficient: !double
     // Gamma and modified Bessel function orders

--- a/training/gordon-group/src/CustomMLPipeline/machineLearning/GPRegression/kernels/SklearnGPRKernelMatern.c3typ
+++ b/training/gordon-group/src/CustomMLPipeline/machineLearning/GPRegression/kernels/SklearnGPRKernelMatern.c3typ
@@ -6,6 +6,8 @@
 type SklearnGPRKernelMatern {
     // Constant that defines the kernel length scale
     lengthScale: !double
+    // Constant prepended to the kernel function (for the variance K(x,x))
+    coefficient: !double
     // Gamma and modified Bessel function orders
     nu: !double
     // the SklearnGPRKernel for this object

--- a/training/gordon-group/src/CustomMLPipeline/machineLearning/GPRegression/kernels/SklearnGPRKernelMatern.py
+++ b/training/gordon-group/src/CustomMLPipeline/machineLearning/GPRegression/kernels/SklearnGPRKernelMatern.py
@@ -4,12 +4,14 @@ def build(this):
     """
     from sklearn.gaussian_process.kernels import Matern
 
-    sklKernel = Matern(length_scale=this.lengthScale, nu=this.nu)
+    sklKernel = this.coefficient * Matern(length_scale=this.lengthScale, nu=this.nu)
 
     kernel_pickled = c3.PythonSerialization.serialize(obj=sklKernel)
     kernel_name = 'Matern'
     kernel_hyperParameters = c3.c3Make(
-        "map<string, double>", {"lengthScale": this.lengthScale,
+        "map<string, double>", {
+            "lengthScale": this.lengthScale,
+            "coefficient": this.coefficient,
             "nu": this.nu
         }
     )


### PR DESCRIPTION
Toward issue #548 , the attributes made available to the user when fitting a GP using the Matern kernel now include a leading coefficient and an array for the length scales (as opposed to only one constant). Also, the GaussianProcessRegressionPipeline Technique will update its kernel during training if the kernel is Matern.